### PR TITLE
📖 Use Gitpod to suggest documentation edits

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -136,7 +136,7 @@
                                     <i class="fa fa-angle-right"></i>
                                 </a>
                             {{/next}}
-                            <a href="https://github.com/gitpod-io/gitpod-docs/edit/master/src/{{ path }}" class="icon-button" target="_blank" title="Edit on GitHub" aria-label="Edit on GitHub">
+                            <a href="https://gitpod.io/#https://github.com/gitpod-io/gitpod-docs" class="icon-button" target="_blank" title="Edit on Gitpod" aria-label="Edit on Gitpod">
                                 <i class="fa fa-edit"></i>
                             </a>
                             <a href="{{ path_to_root }}print.html" title="Print this book" aria-label="Print this book">


### PR DESCRIPTION
Use Gitpod to edit Gitpod documentation

Hindrance:
- Does not link to the direct doc (could not find a way to do so, you guys might have something better up your sleeve)

Benefits:
- No [unfound pages](https://github.com/gitpod-io/gitpod-docs/edit/master/src/index.html)
- No explicit fork required (see attachment)

![](https://user-images.githubusercontent.com/516342/51172713-807b6700-18bc-11e9-831f-862f509e25cf.png)
